### PR TITLE
fixed issue where the same file could not be uploaded more than once

### DIFF
--- a/src/app/tools/imageList/panelButtons/buttonMiddleWare.js
+++ b/src/app/tools/imageList/panelButtons/buttonMiddleWare.js
@@ -1,14 +1,15 @@
-import { reassignReferenceToNewCanvas } from '../../../canvas/canvas';
 import { interruptAllCanvasEvents } from '../../../canvas/mouseInteractions/mouseEvents/resetCanvasUtils/resetCanvasState';
 import { removeActiveButtonPopover } from '../../globalStyling/buttons/popovers';
-import { canSwitchImage } from '../imageList';
+import { reassignReferenceToNewCanvas } from '../../../canvas/canvas';
 import isLeftMouseButtonClick from '../../utils/buttons/clickEvents';
+import { canSwitchImage } from '../imageList';
 
-function interruptAllCanvasEventsBeforeFuncWInputs(placeHolder, funcObj, input) {
+function interruptAllCanvasEventsBeforeFuncWInputs(_, funcObj, input, event) {
   removeActiveButtonPopover();
   interruptAllCanvasEvents();
   funcObj.resetCanvasEventsToDefault();
   funcObj.uploadImageFiles(input);
+  event.target.value = ''; // resetting to prevent Chrome issue of not being able to upload same file twice
 }
 
 function replaceExistingCanvas(func, func2, direction, event) {

--- a/src/app/tools/imageList/uploadImages/uploadImages.js
+++ b/src/app/tools/imageList/uploadImages/uploadImages.js
@@ -1,11 +1,15 @@
-import { addSingleImageToList, addImageFromMultiUploadToList } from '../imageList';
-import { onImageLoad } from './drawImageOnCanvas';
 import { removeNoImagesFoundOnMLModalStyle } from '../../machineLearningModal/views/initiateMachineLearning/style';
+import { addSingleImageToList, addImageFromMultiUploadToList, getImageIdByName } from '../imageList';
+import { onImageLoad } from './drawImageOnCanvas';
 
 // potential to undo and validate in the drag and drop logic,
 // depending on what is being used for upload datasets
-function isFormatValid(file) {
-  return file.type.includes('image/');
+function isFormatValid(imageMetadata) {
+  return imageMetadata.type.includes('image/');
+}
+
+function canUpload(imageMetadata) {
+  return isFormatValid(imageMetadata) && getImageIdByName(imageMetadata.name) === null;
 }
 
 function onMultiFileLoad(imageMetadata, isfirstImage, e) {
@@ -20,7 +24,7 @@ function onMultiFileLoad(imageMetadata, isfirstImage, e) {
 
 function uploadMultipleImages(uploadData) {
   for (let i = 0; i < uploadData.files.length; i += 1) {
-    if (isFormatValid(uploadData.files[0])) {
+    if (canUpload(uploadData.files[i])) {
       const reader = new FileReader();
       const isfirstImage = i === 0;
       reader.onload = onMultiFileLoad.bind(this, uploadData.files[i], isfirstImage);
@@ -29,16 +33,16 @@ function uploadMultipleImages(uploadData) {
   }
 }
 
-function onSingleFileLoad(imageMetaData, e) {
+function onSingleFileLoad(imageMetadata, e) {
   const image = new Image();
   image.src = e.target.result;
   image.onload = onImageLoad;
-  addSingleImageToList(imageMetaData, image);
+  addSingleImageToList(imageMetadata, image);
   removeNoImagesFoundOnMLModalStyle();
 }
 
 function uploadSingleImage(uploadData) {
-  if (isFormatValid(uploadData.files[0])) {
+  if (canUpload(uploadData.files[0])) {
     const reader = new FileReader();
     reader.onload = onSingleFileLoad.bind(this, uploadData.files[0]);
     reader.readAsDataURL(uploadData.files[0]);

--- a/src/app/tools/uploadDatasetsModal/views/uploadDatasets/uploadDatasetFilesHandler.js
+++ b/src/app/tools/uploadDatasetsModal/views/uploadDatasets/uploadDatasetFilesHandler.js
@@ -29,7 +29,7 @@ function validateFileFormat(file) {
   return getAcceptedFileFormat().includes(fileExtension) || file.type.includes('image/');
 }
 
-function uploadDatasetFilesHandler(uploadData) {
+function uploadDatasetFilesHandler(uploadData, event) {
   if (uploadData.files && uploadData.files.length > 0) {
     for (let i = 0; i < uploadData.files.length; i += 1) {
       if (validateFileFormat(uploadData.files[i])) {
@@ -39,6 +39,7 @@ function uploadDatasetFilesHandler(uploadData) {
       }
     }
   }
+  event.target.value = ''; // resetting to prevent Chrome issue of not being able to upload same file twice
 }
 
 function addAlreadyUploadedImages(images) {

--- a/src/devIndexTemplate.html
+++ b/src/devIndexTemplate.html
@@ -162,7 +162,7 @@
       <div id="upload-datasets-modal-buttons" class="buttons modal-buttons">
         <div id="upload-datasets-modal-start-button" class="popup-label-button popup-proceed-button" onclick="moveToSelectFormatView()">Start</div>
         <div id="upload-datasets-modal-back-button" style="display: none" class="popup-label-button popup-back-button" onclick="goBackToSelectFormatView()">Back</div>
-        <input id='upload-datasets-modal-upload-datasets-upload-trigger' type='file' onchange="uploadDatasetFilesHandler(this)" multiple hidden/>
+        <input id='upload-datasets-modal-upload-datasets-upload-trigger' type='file' onchange="uploadDatasetFilesHandler(this, event)" multiple hidden/>
         <div id="upload-datasets-modal-upload-datasets-upload-button" style="display: none" class="popup-label-button popup-proceed-button" onclick="triggerUploadDatasetFiles()">Upload</div>
         <div id="upload-datsets-modal-next-button" style="display: none" class="popup-label-button-disabled" onclick="moveToUploadDatasetsView()">Next</div>
         <div id="upload-datasets-modal-cancel-button" class="popup-label-button popup-cancel-button" onclick="cancelUploadDatasetsModal(true)">Cancel</div>
@@ -324,7 +324,7 @@
               </button>
             </div>
             <div id="remove-images-button-popover" class="core-button-hover-popover image-list-button-hover-popover-v-position">Remove Image</div>
-            <input id='uploadImages' type='file' onchange="uploadImages(this)" multiple accept="image/*" hidden/>
+            <input id='uploadImages' type='file' onchange="uploadImages(this, event)" multiple accept="image/*" hidden/>
             <button id="upload-images-button" class="toolkit-button toolkit-button-default" onmouseup="triggerImageUpload(event)">
               <img id="upload-images-icon" src="assets/svg/method-draw-image - 2020-05-05T022144.694.svg" draggable="false" alt="visibility">
             </button>


### PR DESCRIPTION
Could not import the same file multiple times within the same client session in Chrome. The use case for this is if the user uploads a file, removes it and then needs to upload it again.